### PR TITLE
hopefully fixing concurrency issue

### DIFF
--- a/backend/socket/gameHandler.js
+++ b/backend/socket/gameHandler.js
@@ -86,6 +86,7 @@ async function getLlmResponse(io, roomCode) {
 
     currRounds[roomCode] += 1; 
     io.to(roomCode).emit("round-complete", currRounds[roomCode]);
+    await getLlmInstructions(io, roomCode, currRounds[roomCode]);
 }
 
 export async function getLlmInstructions(io, roomCode, round) {

--- a/my-app/src/admin/AdminInteraction.jsx
+++ b/my-app/src/admin/AdminInteraction.jsx
@@ -61,12 +61,12 @@ export default function AdminInteraction(){
         });
 
 
-        socket.on("round-complete", (nextRound) => {
-            socket.emit('start-round', {
-                roomCode,
-                round: nextRound
-            });
-        });
+        // socket.on("round-complete", (nextRound) => {
+        //     // socket.emit('start-round', {
+        //     //     roomCode,
+        //     //     round: nextRound
+        //     // });
+        // });
 
         socket.on("force-return-to-login", () => {
             navigate("/admin");
@@ -79,7 +79,7 @@ export default function AdminInteraction(){
             socket.off("ai-token");
             socket.off("ai-start");
             socket.off("ai-end");
-            socket.off("round-complete");
+            // socket.off("round-complete");
             socket.off("force-return-to-login");
         };
     }, [socket]);


### PR DESCRIPTION
This is hopefully fixing the concurrency issue where if two games are open at once and the last users both send messages at the same time somehow the llm instructions don't appear. I believe the issue was due to the reliance on websockets for getting llm instructions. Basically after llm response it would send a socket event to frontend and adminInteraction would capture that then send a socket event to start the next round which then called the function for getting the instructions. Now I just have it automatically getting instructions from backend right after the response is finished. 